### PR TITLE
User 도메인의 Board 관련 기능 추가

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -42,6 +42,12 @@ dependencies {
 
     //smtp
     implementation 'org.springframework.boot:spring-boot-starter-mail'
+
+    //querydsl
+    implementation 'com.querydsl:querydsl-jpa:5.0.0:jakarta'
+    annotationProcessor "com.querydsl:querydsl-apt:5.0.0:jakarta"
+    annotationProcessor "jakarta.annotation:jakarta.annotation-api"
+    annotationProcessor "jakarta.persistence:jakarta.persistence-api"
     
     // Security
     implementation 'org.springframework.boot:spring-boot-starter-security'
@@ -57,4 +63,23 @@ dependencies {
 
 test {
     useJUnitPlatform()
+}
+
+test {
+    useJUnitPlatform()
+}
+
+//querydsl build option
+def generated = "src/main/generated"
+
+tasks.withType(JavaCompile) {
+    options.getGeneratedSourceOutputDirectory().set(file(generated))
+}
+
+sourceSets {
+    main.java.srcDirs += [ generated ]
+}
+
+clean {
+    delete file(generated)
 }

--- a/src/main/generated/sparta/a08/trello/board/entity/QBoard.java
+++ b/src/main/generated/sparta/a08/trello/board/entity/QBoard.java
@@ -1,0 +1,53 @@
+package sparta.a08.trello.board.entity;
+
+import static com.querydsl.core.types.PathMetadataFactory.*;
+
+import com.querydsl.core.types.dsl.*;
+
+import com.querydsl.core.types.PathMetadata;
+import javax.annotation.processing.Generated;
+import com.querydsl.core.types.Path;
+
+
+/**
+ * QBoard is a Querydsl query type for Board
+ */
+@Generated("com.querydsl.codegen.DefaultEntitySerializer")
+public class QBoard extends EntityPathBase<Board> {
+
+    private static final long serialVersionUID = 1729724113L;
+
+    public static final QBoard board = new QBoard("board");
+
+    public final sparta.a08.trello.common.QBaseEntity _super = new sparta.a08.trello.common.QBaseEntity(this);
+
+    public final StringPath content = createString("content");
+
+    //inherited
+    public final DateTimePath<java.time.LocalDateTime> createdAt = _super.createdAt;
+
+    public final StringPath filename = createString("filename");
+
+    public final NumberPath<Long> id = createNumber("id", Long.class);
+
+    //inherited
+    public final DateTimePath<java.time.LocalDateTime> lastModifiedAt = _super.lastModifiedAt;
+
+    public final StringPath title = createString("title");
+
+    public final EnumPath<sparta.a08.trello.board.entity.enums.BoardType> visibility = createEnum("visibility", sparta.a08.trello.board.entity.enums.BoardType.class);
+
+    public QBoard(String variable) {
+        super(Board.class, forVariable(variable));
+    }
+
+    public QBoard(Path<? extends Board> path) {
+        super(path.getType(), path.getMetadata());
+    }
+
+    public QBoard(PathMetadata metadata) {
+        super(Board.class, metadata);
+    }
+
+}
+

--- a/src/main/generated/sparta/a08/trello/board/entity/QUserBoard.java
+++ b/src/main/generated/sparta/a08/trello/board/entity/QUserBoard.java
@@ -1,0 +1,57 @@
+package sparta.a08.trello.board.entity;
+
+import static com.querydsl.core.types.PathMetadataFactory.*;
+
+import com.querydsl.core.types.dsl.*;
+
+import com.querydsl.core.types.PathMetadata;
+import javax.annotation.processing.Generated;
+import com.querydsl.core.types.Path;
+import com.querydsl.core.types.dsl.PathInits;
+
+
+/**
+ * QUserBoard is a Querydsl query type for UserBoard
+ */
+@Generated("com.querydsl.codegen.DefaultEntitySerializer")
+public class QUserBoard extends EntityPathBase<UserBoard> {
+
+    private static final long serialVersionUID = -1607312314L;
+
+    private static final PathInits INITS = PathInits.DIRECT2;
+
+    public static final QUserBoard userBoard = new QUserBoard("userBoard");
+
+    public final QBoard board;
+
+    public final EnumPath<sparta.a08.trello.board.entity.enums.UserBoardRole> role = createEnum("role", sparta.a08.trello.board.entity.enums.UserBoardRole.class);
+
+    public final sparta.a08.trello.user.entity.QUser user;
+
+    public final QUserBoardPK userBoardPK;
+
+    public QUserBoard(String variable) {
+        this(UserBoard.class, forVariable(variable), INITS);
+    }
+
+    public QUserBoard(Path<? extends UserBoard> path) {
+        this(path.getType(), path.getMetadata(), PathInits.getFor(path.getMetadata(), INITS));
+    }
+
+    public QUserBoard(PathMetadata metadata) {
+        this(metadata, PathInits.getFor(metadata, INITS));
+    }
+
+    public QUserBoard(PathMetadata metadata, PathInits inits) {
+        this(UserBoard.class, metadata, inits);
+    }
+
+    public QUserBoard(Class<? extends UserBoard> type, PathMetadata metadata, PathInits inits) {
+        super(type, metadata, inits);
+        this.board = inits.isInitialized("board") ? new QBoard(forProperty("board")) : null;
+        this.user = inits.isInitialized("user") ? new sparta.a08.trello.user.entity.QUser(forProperty("user")) : null;
+        this.userBoardPK = inits.isInitialized("userBoardPK") ? new QUserBoardPK(forProperty("userBoardPK")) : null;
+    }
+
+}
+

--- a/src/main/generated/sparta/a08/trello/board/entity/QUserBoardInvite.java
+++ b/src/main/generated/sparta/a08/trello/board/entity/QUserBoardInvite.java
@@ -1,0 +1,53 @@
+package sparta.a08.trello.board.entity;
+
+import static com.querydsl.core.types.PathMetadataFactory.*;
+
+import com.querydsl.core.types.dsl.*;
+
+import com.querydsl.core.types.PathMetadata;
+import javax.annotation.processing.Generated;
+import com.querydsl.core.types.Path;
+import com.querydsl.core.types.dsl.PathInits;
+
+
+/**
+ * QUserBoardInvite is a Querydsl query type for UserBoardInvite
+ */
+@Generated("com.querydsl.codegen.DefaultEntitySerializer")
+public class QUserBoardInvite extends EntityPathBase<UserBoardInvite> {
+
+    private static final long serialVersionUID = -372725009L;
+
+    private static final PathInits INITS = PathInits.DIRECT2;
+
+    public static final QUserBoardInvite userBoardInvite = new QUserBoardInvite("userBoardInvite");
+
+    public final QBoard board;
+
+    public final StringPath email = createString("email");
+
+    public final NumberPath<Long> id = createNumber("id", Long.class);
+
+    public QUserBoardInvite(String variable) {
+        this(UserBoardInvite.class, forVariable(variable), INITS);
+    }
+
+    public QUserBoardInvite(Path<? extends UserBoardInvite> path) {
+        this(path.getType(), path.getMetadata(), PathInits.getFor(path.getMetadata(), INITS));
+    }
+
+    public QUserBoardInvite(PathMetadata metadata) {
+        this(metadata, PathInits.getFor(metadata, INITS));
+    }
+
+    public QUserBoardInvite(PathMetadata metadata, PathInits inits) {
+        this(UserBoardInvite.class, metadata, inits);
+    }
+
+    public QUserBoardInvite(Class<? extends UserBoardInvite> type, PathMetadata metadata, PathInits inits) {
+        super(type, metadata, inits);
+        this.board = inits.isInitialized("board") ? new QBoard(forProperty("board")) : null;
+    }
+
+}
+

--- a/src/main/generated/sparta/a08/trello/board/entity/QUserBoardPK.java
+++ b/src/main/generated/sparta/a08/trello/board/entity/QUserBoardPK.java
@@ -1,0 +1,39 @@
+package sparta.a08.trello.board.entity;
+
+import static com.querydsl.core.types.PathMetadataFactory.*;
+
+import com.querydsl.core.types.dsl.*;
+
+import com.querydsl.core.types.PathMetadata;
+import javax.annotation.processing.Generated;
+import com.querydsl.core.types.Path;
+
+
+/**
+ * QUserBoardPK is a Querydsl query type for UserBoardPK
+ */
+@Generated("com.querydsl.codegen.DefaultEmbeddableSerializer")
+public class QUserBoardPK extends BeanPath<UserBoardPK> {
+
+    private static final long serialVersionUID = 1561095361L;
+
+    public static final QUserBoardPK userBoardPK = new QUserBoardPK("userBoardPK");
+
+    public final NumberPath<Long> boardId = createNumber("boardId", Long.class);
+
+    public final NumberPath<Long> userId = createNumber("userId", Long.class);
+
+    public QUserBoardPK(String variable) {
+        super(UserBoardPK.class, forVariable(variable));
+    }
+
+    public QUserBoardPK(Path<? extends UserBoardPK> path) {
+        super(path.getType(), path.getMetadata());
+    }
+
+    public QUserBoardPK(PathMetadata metadata) {
+        super(UserBoardPK.class, metadata);
+    }
+
+}
+

--- a/src/main/generated/sparta/a08/trello/card/QCard.java
+++ b/src/main/generated/sparta/a08/trello/card/QCard.java
@@ -1,0 +1,51 @@
+package sparta.a08.trello.card;
+
+import static com.querydsl.core.types.PathMetadataFactory.*;
+
+import com.querydsl.core.types.dsl.*;
+
+import com.querydsl.core.types.PathMetadata;
+import javax.annotation.processing.Generated;
+import com.querydsl.core.types.Path;
+import com.querydsl.core.types.dsl.PathInits;
+
+
+/**
+ * QCard is a Querydsl query type for Card
+ */
+@Generated("com.querydsl.codegen.DefaultEntitySerializer")
+public class QCard extends EntityPathBase<Card> {
+
+    private static final long serialVersionUID = 575779776L;
+
+    private static final PathInits INITS = PathInits.DIRECT2;
+
+    public static final QCard card = new QCard("card");
+
+    public final sparta.a08.trello.columns.entity.QColumns columns;
+
+    public final NumberPath<Long> id = createNumber("id", Long.class);
+
+    public QCard(String variable) {
+        this(Card.class, forVariable(variable), INITS);
+    }
+
+    public QCard(Path<? extends Card> path) {
+        this(path.getType(), path.getMetadata(), PathInits.getFor(path.getMetadata(), INITS));
+    }
+
+    public QCard(PathMetadata metadata) {
+        this(metadata, PathInits.getFor(metadata, INITS));
+    }
+
+    public QCard(PathMetadata metadata, PathInits inits) {
+        this(Card.class, metadata, inits);
+    }
+
+    public QCard(Class<? extends Card> type, PathMetadata metadata, PathInits inits) {
+        super(type, metadata, inits);
+        this.columns = inits.isInitialized("columns") ? new sparta.a08.trello.columns.entity.QColumns(forProperty("columns"), inits.get("columns")) : null;
+    }
+
+}
+

--- a/src/main/generated/sparta/a08/trello/columns/entity/QColumns.java
+++ b/src/main/generated/sparta/a08/trello/columns/entity/QColumns.java
@@ -1,0 +1,65 @@
+package sparta.a08.trello.columns.entity;
+
+import static com.querydsl.core.types.PathMetadataFactory.*;
+
+import com.querydsl.core.types.dsl.*;
+
+import com.querydsl.core.types.PathMetadata;
+import javax.annotation.processing.Generated;
+import com.querydsl.core.types.Path;
+import com.querydsl.core.types.dsl.PathInits;
+
+
+/**
+ * QColumns is a Querydsl query type for Columns
+ */
+@Generated("com.querydsl.codegen.DefaultEntitySerializer")
+public class QColumns extends EntityPathBase<Columns> {
+
+    private static final long serialVersionUID = 827090865L;
+
+    private static final PathInits INITS = PathInits.DIRECT2;
+
+    public static final QColumns columns = new QColumns("columns");
+
+    public final sparta.a08.trello.common.QBaseEntity _super = new sparta.a08.trello.common.QBaseEntity(this);
+
+    public final sparta.a08.trello.board.entity.QBoard board;
+
+    public final ListPath<sparta.a08.trello.card.Card, sparta.a08.trello.card.QCard> cards = this.<sparta.a08.trello.card.Card, sparta.a08.trello.card.QCard>createList("cards", sparta.a08.trello.card.Card.class, sparta.a08.trello.card.QCard.class, PathInits.DIRECT2);
+
+    //inherited
+    public final DateTimePath<java.time.LocalDateTime> createdAt = _super.createdAt;
+
+    public final NumberPath<Long> id = createNumber("id", Long.class);
+
+    //inherited
+    public final DateTimePath<java.time.LocalDateTime> lastModifiedAt = _super.lastModifiedAt;
+
+    public final NumberPath<Long> position = createNumber("position", Long.class);
+
+    public final StringPath title = createString("title");
+
+    public QColumns(String variable) {
+        this(Columns.class, forVariable(variable), INITS);
+    }
+
+    public QColumns(Path<? extends Columns> path) {
+        this(path.getType(), path.getMetadata(), PathInits.getFor(path.getMetadata(), INITS));
+    }
+
+    public QColumns(PathMetadata metadata) {
+        this(metadata, PathInits.getFor(metadata, INITS));
+    }
+
+    public QColumns(PathMetadata metadata, PathInits inits) {
+        this(Columns.class, metadata, inits);
+    }
+
+    public QColumns(Class<? extends Columns> type, PathMetadata metadata, PathInits inits) {
+        super(type, metadata, inits);
+        this.board = inits.isInitialized("board") ? new sparta.a08.trello.board.entity.QBoard(forProperty("board")) : null;
+    }
+
+}
+

--- a/src/main/generated/sparta/a08/trello/comment/entity/QComment.java
+++ b/src/main/generated/sparta/a08/trello/comment/entity/QComment.java
@@ -1,0 +1,64 @@
+package sparta.a08.trello.comment.entity;
+
+import static com.querydsl.core.types.PathMetadataFactory.*;
+
+import com.querydsl.core.types.dsl.*;
+
+import com.querydsl.core.types.PathMetadata;
+import javax.annotation.processing.Generated;
+import com.querydsl.core.types.Path;
+import com.querydsl.core.types.dsl.PathInits;
+
+
+/**
+ * QComment is a Querydsl query type for Comment
+ */
+@Generated("com.querydsl.codegen.DefaultEntitySerializer")
+public class QComment extends EntityPathBase<Comment> {
+
+    private static final long serialVersionUID = 1755861873L;
+
+    private static final PathInits INITS = PathInits.DIRECT2;
+
+    public static final QComment comment = new QComment("comment");
+
+    public final sparta.a08.trello.common.QBaseEntity _super = new sparta.a08.trello.common.QBaseEntity(this);
+
+    public final sparta.a08.trello.card.QCard card;
+
+    public final StringPath content = createString("content");
+
+    //inherited
+    public final DateTimePath<java.time.LocalDateTime> createdAt = _super.createdAt;
+
+    public final NumberPath<Long> id = createNumber("id", Long.class);
+
+    //inherited
+    public final DateTimePath<java.time.LocalDateTime> lastModifiedAt = _super.lastModifiedAt;
+
+    public final sparta.a08.trello.user.entity.QUser user;
+
+    public QComment(String variable) {
+        this(Comment.class, forVariable(variable), INITS);
+    }
+
+    public QComment(Path<? extends Comment> path) {
+        this(path.getType(), path.getMetadata(), PathInits.getFor(path.getMetadata(), INITS));
+    }
+
+    public QComment(PathMetadata metadata) {
+        this(metadata, PathInits.getFor(metadata, INITS));
+    }
+
+    public QComment(PathMetadata metadata, PathInits inits) {
+        this(Comment.class, metadata, inits);
+    }
+
+    public QComment(Class<? extends Comment> type, PathMetadata metadata, PathInits inits) {
+        super(type, metadata, inits);
+        this.card = inits.isInitialized("card") ? new sparta.a08.trello.card.QCard(forProperty("card"), inits.get("card")) : null;
+        this.user = inits.isInitialized("user") ? new sparta.a08.trello.user.entity.QUser(forProperty("user")) : null;
+    }
+
+}
+

--- a/src/main/generated/sparta/a08/trello/common/QBaseEntity.java
+++ b/src/main/generated/sparta/a08/trello/common/QBaseEntity.java
@@ -1,0 +1,39 @@
+package sparta.a08.trello.common;
+
+import static com.querydsl.core.types.PathMetadataFactory.*;
+
+import com.querydsl.core.types.dsl.*;
+
+import com.querydsl.core.types.PathMetadata;
+import javax.annotation.processing.Generated;
+import com.querydsl.core.types.Path;
+
+
+/**
+ * QBaseEntity is a Querydsl query type for BaseEntity
+ */
+@Generated("com.querydsl.codegen.DefaultSupertypeSerializer")
+public class QBaseEntity extends EntityPathBase<BaseEntity> {
+
+    private static final long serialVersionUID = 2125971593L;
+
+    public static final QBaseEntity baseEntity = new QBaseEntity("baseEntity");
+
+    public final DateTimePath<java.time.LocalDateTime> createdAt = createDateTime("createdAt", java.time.LocalDateTime.class);
+
+    public final DateTimePath<java.time.LocalDateTime> lastModifiedAt = createDateTime("lastModifiedAt", java.time.LocalDateTime.class);
+
+    public QBaseEntity(String variable) {
+        super(BaseEntity.class, forVariable(variable));
+    }
+
+    public QBaseEntity(Path<? extends BaseEntity> path) {
+        super(path.getType(), path.getMetadata());
+    }
+
+    public QBaseEntity(PathMetadata metadata) {
+        super(BaseEntity.class, metadata);
+    }
+
+}
+

--- a/src/main/generated/sparta/a08/trello/user/entity/QUser.java
+++ b/src/main/generated/sparta/a08/trello/user/entity/QUser.java
@@ -1,0 +1,45 @@
+package sparta.a08.trello.user.entity;
+
+import static com.querydsl.core.types.PathMetadataFactory.*;
+
+import com.querydsl.core.types.dsl.*;
+
+import com.querydsl.core.types.PathMetadata;
+import javax.annotation.processing.Generated;
+import com.querydsl.core.types.Path;
+
+
+/**
+ * QUser is a Querydsl query type for User
+ */
+@Generated("com.querydsl.codegen.DefaultEntitySerializer")
+public class QUser extends EntityPathBase<User> {
+
+    private static final long serialVersionUID = 334353601L;
+
+    public static final QUser user = new QUser("user");
+
+    public final StringPath email = createString("email");
+
+    public final NumberPath<Long> id = createNumber("id", Long.class);
+
+    public final StringPath password = createString("password");
+
+    public final StringPath refreshToken = createString("refreshToken");
+
+    public final StringPath username = createString("username");
+
+    public QUser(String variable) {
+        super(User.class, forVariable(variable));
+    }
+
+    public QUser(Path<? extends User> path) {
+        super(path.getType(), path.getMetadata());
+    }
+
+    public QUser(PathMetadata metadata) {
+        super(User.class, metadata);
+    }
+
+}
+

--- a/src/main/java/sparta/a08/trello/board/dto/BoardResponse.java
+++ b/src/main/java/sparta/a08/trello/board/dto/BoardResponse.java
@@ -6,12 +6,16 @@ import sparta.a08.trello.board.entity.Board;
 
 @Getter
 public class BoardResponse {
+    private final Long boardId;
     private final String title;
     private final String content;
+    private final String imageURL;
 
     @Builder
-    public BoardResponse(Board board) {
+    public BoardResponse(Board board, String imageURL) {
+        this.boardId = board.getId();
         this.title = board.getTitle();
         this.content = board.getContent();
+        this.imageURL = imageURL;
     }
 }

--- a/src/main/java/sparta/a08/trello/board/repository/UserBoardRepository.java
+++ b/src/main/java/sparta/a08/trello/board/repository/UserBoardRepository.java
@@ -11,4 +11,7 @@ public interface UserBoardRepository extends JpaRepository<UserBoard, UserBoardP
 
     @Query("select ub from UserBoard ub join fetch ub.user where ub.board.id = :boardId")
     List<UserBoard> findByBoard_IdJoinUser(Long boardId);
+
+    @Query("select ub from UserBoard ub join fetch ub.board where ub.user.id = :userId")
+    List<UserBoard> findByUser_IdJoinBoard(Long userId);
 }

--- a/src/main/java/sparta/a08/trello/board/service/BoardService.java
+++ b/src/main/java/sparta/a08/trello/board/service/BoardService.java
@@ -64,4 +64,11 @@ public interface BoardService {
      * @param email Board 사용자 추가 대상자 이메일
      * */
     void createUserBoard(Long boardId, String email);
+
+    /**
+     * User가 속해있는 Board 리스트 조회
+     * @param user 조회 대상 user
+     * @return 내 보드 조회 결과 리스트
+     * */
+    List<BoardResponse> readMyBoard(User user);
 }

--- a/src/main/java/sparta/a08/trello/board/service/BoardServiceImpl.java
+++ b/src/main/java/sparta/a08/trello/board/service/BoardServiceImpl.java
@@ -24,6 +24,7 @@ import sparta.a08.trello.common.smtp.SmtpUtil;
 import sparta.a08.trello.user.entity.User;
 import sparta.a08.trello.user.repository.UserRepository;
 
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
 
@@ -54,7 +55,7 @@ public class BoardServiceImpl implements BoardService {
         //UserBoard 생성
         createUserBoard(user, board, UserBoardRole.ADMIN);
 
-        return new BoardResponse(board);
+        return new BoardResponse(board, s3Util.getImageURL(S3Const.S3_DIR_BOARD, board.getFilename()));
     }
 
     @Override
@@ -64,7 +65,7 @@ public class BoardServiceImpl implements BoardService {
 
         findBoard.update(request.getTitle(), request.getContent());
 
-        return new BoardResponse(findBoard);
+        return new BoardResponse(findBoard, s3Util.getImageURL(S3Const.S3_DIR_BOARD, findBoard.getFilename()));
     }
 
     @Override
@@ -97,7 +98,7 @@ public class BoardServiceImpl implements BoardService {
 
         boardRepository.delete(findBoard);
 
-        return new BoardResponse(findBoard);
+        return new BoardResponse(findBoard, s3Util.getImageURL(S3Const.S3_DIR_BOARD, findBoard.getFilename()));
     }
 
     @Override
@@ -159,6 +160,21 @@ public class BoardServiceImpl implements BoardService {
 
         //UserBoardInvite 삭제
         userBoardInviteRepository.deleteByEmailAndBoard_Id(findUser.getEmail(), findBoard.getId());
+    }
+
+    @Override
+    public List<BoardResponse> readMyBoard(User user) {
+        List<UserBoard> userBoards = userBoardRepository.findByUser_IdJoinBoard(user.getId());
+
+        //response mapping list
+        List<BoardResponse> res = new ArrayList<>();
+
+        for (UserBoard userBoard : userBoards) {
+            Board board = userBoard.getBoard();
+            res.add(new BoardResponse(board, s3Util.getImageURL(S3Const.S3_DIR_BOARD, board.getFilename())));
+        }
+
+        return res;
     }
 
 

--- a/src/main/java/sparta/a08/trello/common/configuration/WebSecurityConfig.java
+++ b/src/main/java/sparta/a08/trello/common/configuration/WebSecurityConfig.java
@@ -12,6 +12,9 @@ import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.security.web.SecurityFilterChain;
 import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
+import org.springframework.security.web.util.matcher.AntPathRequestMatcher;
+import org.springframework.security.web.util.matcher.OrRequestMatcher;
+import org.springframework.security.web.util.matcher.RequestMatcher;
 import sparta.a08.trello.common.jwt.JwtAuthorizationFilter;
 import sparta.a08.trello.common.jwt.JwtUtil;
 import sparta.a08.trello.common.security.UserDetailsService;
@@ -48,11 +51,21 @@ public class WebSecurityConfig {
         http.authorizeHttpRequests((authorizeHttpRequest) ->
                 authorizeHttpRequest
                         .requestMatchers(PathRequest.toStaticResources().atCommonLocations()).permitAll()
-                        .requestMatchers("/api/users/**").permitAll()
+                        .requestMatchers(publicEndPoints()).permitAll()
                         .anyRequest().authenticated()
         );
         http.addFilterBefore(jwtAuthorizationFilter(), UsernamePasswordAuthenticationFilter.class);
 
         return http.build();
+    }
+
+    private RequestMatcher publicEndPoints() {
+        return new OrRequestMatcher(
+                //User
+                new AntPathRequestMatcher("/api/users/**"),
+
+                //Board
+                new AntPathRequestMatcher("/api/boards/{boardId}/users/approve")
+        );
     }
 }

--- a/src/main/java/sparta/a08/trello/user/controller/UserController.java
+++ b/src/main/java/sparta/a08/trello/user/controller/UserController.java
@@ -7,6 +7,8 @@ import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
+import sparta.a08.trello.board.dto.BoardResponse;
+import sparta.a08.trello.board.service.BoardServiceImpl;
 import sparta.a08.trello.common.CommonResponseDTO;
 import sparta.a08.trello.common.jwt.JwtUtil;
 import sparta.a08.trello.common.security.UserDetailsImpl;
@@ -23,6 +25,7 @@ import java.util.List;
 public class UserController {
 
     private final UserService userService;
+    private final BoardServiceImpl boardService;
 
     private final JwtUtil jwtUtil;
 
@@ -60,6 +63,15 @@ public class UserController {
     ) {
         return ResponseEntity.status(HttpStatus.OK).body(
                 userService.searchUser(keyword)
+        );
+    }
+
+    @GetMapping("/boards")
+    public ResponseEntity<List<BoardResponse>> readMyBoard(
+            @AuthenticationPrincipal UserDetailsImpl userDetails
+    ) {
+        return ResponseEntity.status(HttpStatus.OK).body(
+                boardService.readMyBoard(userDetails.getUser())
         );
     }
 }

--- a/src/main/java/sparta/a08/trello/user/controller/UserController.java
+++ b/src/main/java/sparta/a08/trello/user/controller/UserController.java
@@ -11,8 +11,11 @@ import sparta.a08.trello.common.CommonResponseDTO;
 import sparta.a08.trello.common.jwt.JwtUtil;
 import sparta.a08.trello.common.security.UserDetailsImpl;
 import sparta.a08.trello.user.dto.UserRequestDTO;
+import sparta.a08.trello.user.dto.UserSearchResponseDTO;
 import sparta.a08.trello.user.entity.User;
 import sparta.a08.trello.user.service.UserService;
+
+import java.util.List;
 
 @RequestMapping("/api/users")
 @RestController
@@ -51,4 +54,12 @@ public class UserController {
         return ResponseEntity.ok().body(new CommonResponseDTO("로그아웃 성공", HttpStatus.OK.value()));
     }
 
+    @GetMapping("")
+    public ResponseEntity<List<UserSearchResponseDTO>> searchUser(
+            @RequestParam("keyword") String keyword
+    ) {
+        return ResponseEntity.status(HttpStatus.OK).body(
+                userService.searchUser(keyword)
+        );
+    }
 }

--- a/src/main/java/sparta/a08/trello/user/dto/UserSearchResponseDTO.java
+++ b/src/main/java/sparta/a08/trello/user/dto/UserSearchResponseDTO.java
@@ -1,0 +1,18 @@
+package sparta.a08.trello.user.dto;
+
+import lombok.Getter;
+import sparta.a08.trello.user.entity.User;
+
+@Getter
+public class UserSearchResponseDTO {
+
+    private final String email;
+    private final String username;
+//    private String imageURL;
+
+    public UserSearchResponseDTO(User user) {
+        this.email = user.getEmail();
+        this.username = user.getUsername();
+//        this.imageURL = user.getImageURL;
+    }
+}

--- a/src/main/java/sparta/a08/trello/user/repository/UserQueryRepository.java
+++ b/src/main/java/sparta/a08/trello/user/repository/UserQueryRepository.java
@@ -1,0 +1,10 @@
+package sparta.a08.trello.user.repository;
+
+import sparta.a08.trello.user.entity.User;
+
+import java.util.List;
+
+public interface UserQueryRepository {
+
+    List<User> searchUser(UserSearchCond cond);
+}

--- a/src/main/java/sparta/a08/trello/user/repository/UserQueryRepositoryImpl.java
+++ b/src/main/java/sparta/a08/trello/user/repository/UserQueryRepositoryImpl.java
@@ -1,0 +1,32 @@
+package sparta.a08.trello.user.repository;
+
+import com.querydsl.core.BooleanBuilder;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import jakarta.persistence.EntityManager;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Repository;
+import sparta.a08.trello.user.entity.QUser;
+import sparta.a08.trello.user.entity.User;
+
+import java.util.List;
+
+@Repository
+@RequiredArgsConstructor
+public class UserQueryRepositoryImpl implements UserQueryRepository {
+
+    private final EntityManager em;
+
+    @Override
+    public List<User> searchUser(UserSearchCond cond) {
+
+        BooleanBuilder builder = new BooleanBuilder();
+        builder.and(QUser.user.email.like(cond.getKeyword()));
+
+        JPAQueryFactory query = new JPAQueryFactory(em);
+
+        return query
+                .selectFrom(QUser.user)
+                .where(builder)
+                .fetch();
+    }
+}

--- a/src/main/java/sparta/a08/trello/user/repository/UserSearchCond.java
+++ b/src/main/java/sparta/a08/trello/user/repository/UserSearchCond.java
@@ -1,0 +1,13 @@
+package sparta.a08.trello.user.repository;
+
+import lombok.Getter;
+
+@Getter
+public class UserSearchCond {
+
+    private final String keyword;
+
+    public UserSearchCond(String keyword) {
+        this.keyword = keyword;
+    }
+}

--- a/src/main/java/sparta/a08/trello/user/service/UserService.java
+++ b/src/main/java/sparta/a08/trello/user/service/UserService.java
@@ -6,9 +6,14 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import sparta.a08.trello.common.exception.CustomErrorCode;
 import sparta.a08.trello.common.exception.CustomException;
+import sparta.a08.trello.user.dto.UserSearchResponseDTO;
+import sparta.a08.trello.user.repository.UserQueryRepositoryImpl;
 import sparta.a08.trello.user.repository.UserRepository;
 import sparta.a08.trello.user.dto.UserRequestDTO;
 import sparta.a08.trello.user.entity.User;
+import sparta.a08.trello.user.repository.UserSearchCond;
+
+import java.util.List;
 
 @Service
 @RequiredArgsConstructor
@@ -17,6 +22,7 @@ public class UserService {
     private final PasswordEncoder passwordEncoder;
 
     private final UserRepository userRepository;
+    private final UserQueryRepositoryImpl userQueryRepository;
 
     public void signup(UserRequestDTO userRequestDTO) {
         String email = userRequestDTO.getEmail();
@@ -68,5 +74,10 @@ public class UserService {
 
     public boolean isPasswordConfirmed(UserRequestDTO userRequestDTO) {
         return userRequestDTO.getPassword().equals(userRequestDTO.getConfirmPassword());
+    }
+
+    public List<UserSearchResponseDTO> searchUser(String keyword) {
+        return userQueryRepository.searchUser(new UserSearchCond(keyword))
+                .stream().map(UserSearchResponseDTO::new).toList();
     }
 }


### PR DESCRIPTION
## 개요
- User 도메인의 Board 관련 기능 추가

## 작업사항
- 조건 검색을 위한 querydsl 의존성 및 Q객체 추가
- 사용자 검색 기능 추가 (email로 검색)
- 사용자가 속해있는 Board 조회 기능 추가

## 변경로직
- WebSecurityConfig에서 requestMatcher에 직접 들어가던 url을 publicEndPoints() 메서드로 분리

## 관련 이슈